### PR TITLE
fix(cli): guard missing 'websockets' on all CDP commands before auth (#3)

### DIFF
--- a/src/flarecrawl/browser_cookies.py
+++ b/src/flarecrawl/browser_cookies.py
@@ -4,7 +4,8 @@ Supports two backends:
   - rookiepy (preferred, Rust-based, faster)
   - browser-cookie3 (fallback, pure Python, wider Windows support)
 
-Install either: uv pip install rookiepy  OR  pip install browser-cookie3
+Install the cookies extra: uv tool install 'flarecrawl[cookies]'
+(faster Rust backend instead: uv tool install flarecrawl --with rookiepy)
 """
 
 from __future__ import annotations
@@ -34,7 +35,8 @@ def _require_cookie_lib() -> None:
     if _backend is None:
         raise FlareCrawlError(
             "Browser cookie extraction requires rookiepy or browser-cookie3. "
-            "Install with: pip install browser-cookie3  (or: uv pip install rookiepy)",
+            "Install the cookies extra: uv tool install 'flarecrawl[cookies]'  "
+            "(faster Rust backend instead: uv tool install flarecrawl --with rookiepy)",
             code="MISSING_DEPENDENCY",
         )
 

--- a/src/flarecrawl/cdp.py
+++ b/src/flarecrawl/cdp.py
@@ -25,8 +25,8 @@ except ImportError:
 def _require_websockets() -> None:
     if websockets is None:
         raise FlareCrawlError(
-            "CDP requires the 'websockets' package. "
-            "Install with: uv pip install 'flarecrawl[cdp]'  (or: uv pip install websockets)",
+            "CDP requires the 'websockets' package. Install the cdp extra: "
+            "uv tool install 'flarecrawl[cdp]'  (in a project: uv add 'flarecrawl[cdp]')",
             code="MISSING_DEPENDENCY",
         )
 

--- a/src/flarecrawl/cdp.py
+++ b/src/flarecrawl/cdp.py
@@ -25,7 +25,8 @@ except ImportError:
 def _require_websockets() -> None:
     if websockets is None:
         raise FlareCrawlError(
-            "CDP requires the 'websockets' package. Install with: uv pip install websockets",
+            "CDP requires the 'websockets' package. "
+            "Install with: uv pip install 'flarecrawl[cdp]'  (or: uv pip install websockets)",
             code="MISSING_DEPENDENCY",
         )
 

--- a/src/flarecrawl/cli/_common.py
+++ b/src/flarecrawl/cli/_common.py
@@ -112,7 +112,7 @@ def _error(
         _output_json(error_obj)
     else:
         # Escape the message — it's data, not markup. Without this, literal
-        # brackets in a message (e.g. the "uv pip install 'flarecrawl[cdp]'"
+        # brackets in a message (e.g. the "uv tool install 'flarecrawl[cdp]'"
         # dependency hint) are parsed as Rich style tags and silently stripped,
         # turning an actionable install command into a broken one.
         console.print(f"[red]Error:[/red] {escape(message)}")
@@ -329,7 +329,8 @@ def _apply_browser_cookies(
         from ..browser_cookies import grab_cookies
     except ImportError:
         _error(
-            "Browser cookie extraction requires rookiepy. Install with: uv pip install rookiepy",
+            "Browser cookie extraction requires a cookie backend. "
+            "Install the cookies extra: uv tool install 'flarecrawl[cookies]'",
             "MISSING_DEPENDENCY", EXIT_ERROR, as_json=as_json,
         )
         return None  # unreachable — _error raises
@@ -367,8 +368,8 @@ def _require_cdp_websockets(as_json: bool = False) -> None:
 
     if _ws is None:
         _error(
-            "CDP requires the 'websockets' package. "
-            "Install with: uv pip install 'flarecrawl[cdp]'  (or: uv pip install websockets)",
+            "CDP requires the 'websockets' package. Install the cdp extra: "
+            "uv tool install 'flarecrawl[cdp]'  (in a project: uv add 'flarecrawl[cdp]')",
             "MISSING_DEPENDENCY", EXIT_ERROR, as_json=as_json,
         )
 

--- a/src/flarecrawl/cli/_common.py
+++ b/src/flarecrawl/cli/_common.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 
 from ..client import Client, FlareCrawlError
 from ..config import (
@@ -110,7 +111,11 @@ def _error(
     if as_json:
         _output_json(error_obj)
     else:
-        console.print(f"[red]Error:[/red] {message}")
+        # Escape the message — it's data, not markup. Without this, literal
+        # brackets in a message (e.g. the "uv pip install 'flarecrawl[cdp]'"
+        # dependency hint) are parsed as Rich style tags and silently stripped,
+        # turning an actionable install command into a broken one.
+        console.print(f"[red]Error:[/red] {escape(message)}")
 
     raise typer.Exit(exit_code)
 
@@ -348,6 +353,26 @@ def _get_client(as_json: bool = False, cache_ttl: int = 3600, proxy: str | None 
     return Client(cache_ttl=cache_ttl, proxy=proxy)
 
 
+def _require_cdp_websockets(as_json: bool = False) -> None:
+    """Guard the optional `websockets` dependency for CDP.
+
+    Emits a clean, actionable MISSING_DEPENDENCY error (exit 1) instead of a
+    misleading "Not authenticated" or a deep traceback. Call this BEFORE any
+    auth or network work so a missing install is the first thing reported.
+
+    The import never raises — `cdp.py` sets `websockets = None` when the package
+    is absent — so an explicit `is None` check is the only reliable guard.
+    """
+    from ..cdp import websockets as _ws
+
+    if _ws is None:
+        _error(
+            "CDP requires the 'websockets' package. "
+            "Install with: uv pip install 'flarecrawl[cdp]'  (or: uv pip install websockets)",
+            "MISSING_DEPENDENCY", EXIT_ERROR, as_json=as_json,
+        )
+
+
 def _get_cdp_client(
     as_json: bool = False,
     keep_alive: int = 0,
@@ -355,18 +380,12 @@ def _get_cdp_client(
     proxy: str | None = None,
 ):
     """Create and connect a CDP WebSocket client."""
-    from ..cdp import CDPClient, websockets as _ws
+    from ..cdp import CDPClient
 
-    # Guard the optional dependency up front — before the auth/network checks below —
-    # so a missing install yields an actionable message instead of a misleading
-    # "Not authenticated". The import itself never raises (cdp.py sets websockets=None
-    # when the package is absent), so checking it explicitly is the only reliable guard.
-    if _ws is None:
-        _error(
-            "CDP requires the 'websockets' package. "
-            "Install with: uv pip install 'flarecrawl[cdp]'  (or: uv pip install websockets)",
-            "MISSING_DEPENDENCY", EXIT_ERROR, as_json=as_json,
-        )
+    # Guard the optional dependency up front — before the auth/network checks
+    # below — so a missing install yields an actionable message instead of a
+    # misleading "Not authenticated".
+    _require_cdp_websockets(as_json)
 
     from ..config import get_proxy
     account_id = get_account_id()

--- a/src/flarecrawl/cli/frontier_cmds.py
+++ b/src/flarecrawl/cli/frontier_cmds.py
@@ -208,7 +208,7 @@ def videos(
     download: Annotated[bool, typer.Option("--download", help="Download videos via yt-dlp at highest resolution")] = False,
     download_dir: Annotated[Path | None, typer.Option("--download-dir", help="Directory for downloaded videos")] = None,
     browser_cookies: Annotated[str | None, typer.Option("--browser-cookies", help="Grab cookies from local browser (chrome|firefox)")] = None,
-    yt_dlp: Annotated[bool, typer.Option("--yt-dlp", help="Run discovered URLs through yt-dlp's extractor registry to resolve provider-specific embeds (DVIDS, Vimeo with auth, etc.). Optional dep: pip install flarecrawl[videos].")] = False,
+    yt_dlp: Annotated[bool, typer.Option("--yt-dlp", help="Run discovered URLs through yt-dlp's extractor registry to resolve provider-specific embeds (DVIDS, Vimeo with auth, etc.). Optional dep: uv tool install 'flarecrawl[videos]'.")] = False,
 ):
     """Discover video URLs on a web page.
 
@@ -402,7 +402,7 @@ def videos(
         import subprocess
         ytdlp = shutil.which("yt-dlp")
         if not ytdlp:
-            _error("yt-dlp not found. Install with: uv pip install yt-dlp", "MISSING_DEPENDENCY", EXIT_ERROR, as_json=json_output)
+            _error("yt-dlp not found. Install the videos extra: uv tool install 'flarecrawl[videos]'", "MISSING_DEPENDENCY", EXIT_ERROR, as_json=json_output)
             return
         dl_dir = download_dir or Path(".")
         dl_dir.mkdir(parents=True, exist_ok=True)

--- a/src/flarecrawl/cli/mcp_cmd.py
+++ b/src/flarecrawl/cli/mcp_cmd.py
@@ -29,7 +29,7 @@ def mcp_cmd(
     5 orientation + 5 T1 composite + 17 T2 curated + 9 T3 raw.
 
     Requires the mcp extra:
-        uv pip install 'flarecrawl[mcp]'
+        uv tool install 'flarecrawl[mcp]'
 
     Usage in Claude Code (.mcp.json):
         {"mcpServers": {"flarecrawl": {"command": "flarecrawl", "args": ["mcp"]}}}
@@ -39,7 +39,7 @@ def mcp_cmd(
     except ImportError:
         typer.echo(
             "The 'mcp' package is not installed. "
-            "Install it with: uv pip install 'flarecrawl[mcp]'",
+            "Install it with: uv tool install 'flarecrawl[mcp]'",
             err=True,
         )
         raise typer.Exit(1) from None

--- a/src/flarecrawl/cli/recipe.py
+++ b/src/flarecrawl/cli/recipe.py
@@ -16,6 +16,7 @@ from ._common import (
     EXIT_VALIDATION,
     _error,
     _get_client,
+    _handle_api_error,
     _output_json,
     _output_ndjson,
     _output_text,
@@ -80,6 +81,12 @@ def recipe_command(
     except RecipeError as e:
         _error(f"{e}  (recipe format + step kinds: flarecrawl guide recipe)",
                "VALIDATION_ERROR", EXIT_VALIDATION, as_json=json_output)
+        return
+    except FlareCrawlError as e:
+        # Notably the missing-`websockets` MISSING_DEPENDENCY guard — surface it
+        # as a clean error (exit 1 / JSON envelope) instead of an uncaught
+        # traceback. RecipeError is independent of FlareCrawlError, so order is moot.
+        _handle_api_error(e, as_json=json_output)
         return
 
     if dry_run:

--- a/src/flarecrawl/cli/recipe.py
+++ b/src/flarecrawl/cli/recipe.py
@@ -259,7 +259,7 @@ def batch_config(
     try:
         import yaml
     except ImportError:
-        _error("PyYAML required for batch config. Install: pip install pyyaml",
+        _error("PyYAML required for batch config. Install the recipes extra: uv tool install 'flarecrawl[recipes]'",
                "VALIDATION_ERROR", EXIT_VALIDATION)
         return
 

--- a/src/flarecrawl/cli/scrape.py
+++ b/src/flarecrawl/cli/scrape.py
@@ -47,6 +47,7 @@ from ._common import (
     _parse_auth,
     _parse_body,
     _parse_headers,
+    _require_cdp_websockets,
     _run_then_fetch,
     _sanitize_filename,
     _validate_url,
@@ -1315,6 +1316,16 @@ def scrape(
     cache_ttl = 0 if no_cache else DEFAULT_CACHE_TTL
     from ..config import get_proxy
     effective_proxy = proxy or get_proxy()
+
+    # If any flag promoted this scrape to CDP, the optional `websockets` package
+    # is mandatory. Guard it here — after all arg validation, before the auth
+    # check below — so a missing install reports the dependency, not a
+    # misleading "Not authenticated" (issue #3). The dedicated CDP commands
+    # guard inside _get_cdp_client; scrape builds the REST client (which checks
+    # auth) first, so it needs its own early guard.
+    if cdp:
+        _require_cdp_websockets(json_output or is_batch_mode)
+
     # Defer auth when --paywall is set: bypass uses direct HTTP, not CF API.
     # Client is created only if credentials exist (needed as fallback).
     if paywall:

--- a/src/flarecrawl/fetch.py
+++ b/src/flarecrawl/fetch.py
@@ -241,7 +241,7 @@ def download_binary_stealth(
         from curl_cffi import requests as cffi_requests
     except ImportError as exc:
         raise ImportError(
-            "Stealth download requires curl_cffi. Install with: uv pip install curl_cffi"
+            "Stealth download requires curl_cffi. Install the stealth extra: uv tool install 'flarecrawl[stealth]'"
         ) from exc
 
     start = time.time()

--- a/src/flarecrawl/local_browser.py
+++ b/src/flarecrawl/local_browser.py
@@ -13,7 +13,7 @@ Why this exists:
   - Free tier users who don't want to pay for Workers Paid plan can use
     this as a pure-local alternative.
 
-Optional dependency: ``pip install flarecrawl[local-browser]`` pulls
+Optional dependency: ``uv tool install 'flarecrawl[local-browser]'`` pulls
 ``playwright`` and downloads the headless-shell binary.
 """
 
@@ -47,9 +47,10 @@ def _resolve_chromium_path() -> str:
         from playwright.sync_api import sync_playwright
     except ImportError as exc:
         raise LocalBrowserError(
-            "Local browser support requires Playwright. Install with: "
-            "uv pip install 'flarecrawl[local-browser]'  "
-            "(or: uv pip install playwright && playwright install chromium)"
+            "Local browser support requires Playwright. Install the "
+            "local-browser extra: uv tool install 'flarecrawl[local-browser]'  "
+            "(in a project: uv add 'flarecrawl[local-browser]'), "
+            "then: playwright install chromium"
         ) from exc
 
     # Open a short-lived Playwright handle just to read the chromium path

--- a/src/flarecrawl/mcp_serve.py
+++ b/src/flarecrawl/mcp_serve.py
@@ -13,7 +13,7 @@ Usage (programmatic):
     serve(read_only=True)   # read-only mode
 
 The ``mcp`` package must be installed:
-    uv pip install 'flarecrawl[mcp]'
+    uv tool install 'flarecrawl[mcp]'
 """
 
 from __future__ import annotations
@@ -71,7 +71,7 @@ def serve(read_only: bool = False) -> None:
     except ImportError as exc:
         raise ImportError(
             "The 'mcp' package is required to run the MCP server. "
-            "Install it with: uv pip install 'flarecrawl[mcp]'"
+            "Install it with: uv tool install 'flarecrawl[mcp]'"
         ) from exc
 
     import asyncio

--- a/src/flarecrawl/mcp_tools/_exec.py
+++ b/src/flarecrawl/mcp_tools/_exec.py
@@ -313,11 +313,11 @@ def _check_optional_deps() -> dict[str, bool]:
 def missing_dep_install_hint(dep_name: str) -> str:
     """Return the uv install command for a missing dep."""
     _hints = {
-        "stealth (curl_cffi)": "uv pip install 'flarecrawl[stealth]'  # or: uv add curl_cffi",
-        "cdp (websockets)": "uv pip install 'flarecrawl[cdp]'  # or: uv add websockets",
-        "local-browser (playwright)": "uv pip install 'flarecrawl[local-browser]' && playwright install chromium",
+        "stealth (curl_cffi)": "uv tool install 'flarecrawl[stealth]'  # in a project: uv add 'flarecrawl[stealth]'",
+        "cdp (websockets)": "uv tool install 'flarecrawl[cdp]'  # in a project: uv add 'flarecrawl[cdp]'",
+        "local-browser (playwright)": "uv tool install 'flarecrawl[local-browser]' && playwright install chromium",
         "search (JINA_API_KEY)": "export JINA_API_KEY=<your-key>  # free at jina.ai",
-        "recipes (pyyaml)": "uv pip install 'flarecrawl[recipes]'  # or: uv add pyyaml",
-        "videos (yt-dlp)": "uv pip install 'flarecrawl[videos]'  # or: uv add yt-dlp",
+        "recipes (pyyaml)": "uv tool install 'flarecrawl[recipes]'  # in a project: uv add 'flarecrawl[recipes]'",
+        "videos (yt-dlp)": "uv tool install 'flarecrawl[videos]'  # in a project: uv add 'flarecrawl[videos]'",
     }
     return _hints.get(dep_name, f"uv add {dep_name}")

--- a/src/flarecrawl/p6.py
+++ b/src/flarecrawl/p6.py
@@ -236,6 +236,15 @@ def run_p6(
     mint_fn = mint_fn or _default_mint_fn
     replay_fn = replay_fn or _default_replay_fn
 
+    # The default minter drives a local Chromium over CDP, which needs the
+    # optional `websockets` package. Guard it up front — before any jar I/O or
+    # browser launch — so a missing install fails fast with an actionable
+    # MISSING_DEPENDENCY error instead of a deep traceback. Injected mint_fns
+    # (tests, custom flows) don't touch CDP, so only guard the default path.
+    if mint_fn is _default_mint_fn:
+        from .cdp import _require_websockets
+        _require_websockets()
+
     def emit(event: str, **payload) -> None:
         if on_event:
             on_event(event, payload)

--- a/src/flarecrawl/recipe.py
+++ b/src/flarecrawl/recipe.py
@@ -120,7 +120,7 @@ def load_recipe(path: Path) -> dict:
     try:
         import yaml
     except ImportError as exc:
-        raise RecipeError("YAML support requires PyYAML: uv pip install pyyaml") from exc
+        raise RecipeError("YAML support requires PyYAML. Install the recipes extra: uv tool install 'flarecrawl[recipes]'") from exc
 
     if not path.exists():
         raise RecipeError(f"Recipe not found: {path}")

--- a/src/flarecrawl/recipe.py
+++ b/src/flarecrawl/recipe.py
@@ -244,9 +244,16 @@ def run(
         return summary
 
     # Late import — runtime CDP session lives only inside this branch.
-    from .cdp import BodyCapture, CDPClient
+    from .cdp import BodyCapture, CDPClient, _require_websockets
     from .config import get_account_id, get_api_token
     from .local_browser import LocalBrowser
+
+    # Guard the optional `websockets` dependency before launching a browser or
+    # touching the network, so a missing install yields an actionable
+    # MISSING_DEPENDENCY error (caught cleanly by recipe_command) instead of a
+    # raw traceback from deep inside CDPClient. Every non-dry-run recipe needs
+    # CDP (both browser: local and CF-hosted connect over a WebSocket).
+    _require_websockets()
 
     use_local = data.get("browser") == "local"
     headed = bool(data.get("headed"))

--- a/src/flarecrawl/robots.py
+++ b/src/flarecrawl/robots.py
@@ -45,7 +45,7 @@ def _warn_fallback_once() -> None:
     if not _FALLBACK_LOGGED:
         logger.warning(
             "protego is not installed; robots.txt will allow all URLs. "
-            "Install with: pip install 'flarecrawl[perf]'"
+            "Install the perf extra: uv tool install 'flarecrawl[perf]'"
         )
         _FALLBACK_LOGGED = True
 

--- a/src/flarecrawl/telemetry.py
+++ b/src/flarecrawl/telemetry.py
@@ -228,7 +228,7 @@ def init_tracing(
             if not _warned_missing:
                 warnings.warn(
                     "OpenTelemetry not installed; tracing disabled. "
-                    "Install with `pip install flarecrawl[perf]`.",
+                    "Install the perf extra: `uv tool install 'flarecrawl[perf]'`.",
                     stacklevel=2,
                 )
                 _warned_missing = True

--- a/tests/live/test_interact_live.py
+++ b/tests/live/test_interact_live.py
@@ -110,7 +110,7 @@ class TestCDPInteract:
 
     These require:
     1. CF auth configured
-    2. websockets package installed (pip install flarecrawl[cdp])
+    2. websockets package installed (uv tool install 'flarecrawl[cdp]')
     3. Local HTTP server running (handled by local_server fixture)
     """
 

--- a/tests/test_fetch_stealth.py
+++ b/tests/test_fetch_stealth.py
@@ -29,7 +29,7 @@ def test_missing_curl_cffi_raises_helpful_error(tmp_path, monkeypatch):
         download_binary_stealth("https://example.com/x", tmp_path / "out.pdf")
     msg = str(exc_info.value)
     assert "curl_cffi" in msg
-    assert "uv pip install" in msg
+    assert "uv tool install" in msg
 
 
 def test_writes_file_with_mock_session(tmp_path, monkeypatch):

--- a/tests/test_issue_regressions.py
+++ b/tests/test_issue_regressions.py
@@ -174,7 +174,7 @@ class TestCdpWebsocketsGuard:
             assert "websockets" in payload["error"]["message"].lower()
 
     def test_install_hint_brackets_survive_rich_markup(self, mock_credentials):
-        """Regression: the actionable hint `uv pip install 'flarecrawl[cdp]'`
+        """Regression: the actionable hint `uv tool install 'flarecrawl[cdp]'`
         must render with the `[cdp]` extra intact in human (text) mode. Rich
         treats `[cdp]` as a style tag and silently strips it unless the message
         is escaped — which turned the install command into a broken one."""

--- a/tests/test_issue_regressions.py
+++ b/tests/test_issue_regressions.py
@@ -8,6 +8,7 @@
 import json
 from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
 from flarecrawl.cli import app
@@ -75,22 +76,151 @@ class TestCrawlTimeoutRecovery:
         assert not out.exists(), "non-timeout errors should not produce an output file"
 
 
+def _cdp_invocations(tmp_path):
+    """Every CLI command that depends on CDP / the optional `websockets`
+    package, with a minimal invocation that reaches the CDP boundary.
+
+    Covers both the guarded factory path (`_get_cdp_client`) and the two
+    direct-construction bypasses fixed for #3 (`p6`, `recipe`). Each must
+    surface the missing dependency cleanly — never a misleading "Not
+    authenticated", never a raw traceback.
+    """
+    cookies = tmp_path / "cookies.json"
+    jar = tmp_path / "jar.json"
+    recipe = tmp_path / "flow.yml"
+    recipe.write_text(
+        "version: 1\ngoto: https://example.com\nbrowser: local\nsteps:\n  - wait: 100ms\n",
+        encoding="utf-8",
+    )
+    return [
+        # --- guarded via _get_cdp_client ---
+        ("design extract", ["design", "extract", "https://example.com"]),
+        ("design coherence", ["design", "coherence", "https://example.com"]),
+        ("design diff", ["design", "diff", "https://a.com", "https://b.com"]),
+        ("cdp connect", ["cdp", "connect"]),
+        ("interact", ["interact", "https://example.com", "--click", ".x"]),
+        ("webmcp discover", ["webmcp", "discover", "https://example.com"]),
+        ("webmcp call", ["webmcp", "call", "https://example.com", "--tool", "t"]),
+        ("videos --interactive", ["videos", "https://example.com", "--interactive"]),
+        ("scrape --cdp", ["scrape", "https://example.com", "--cdp"]),
+        ("scrape --interactive", ["scrape", "https://example.com", "--interactive"]),
+        ("scrape --live-view", ["scrape", "https://example.com", "--live-view"]),
+        ("scrape --record", ["scrape", "https://example.com", "--record"]),
+        ("scrape --keep-alive", ["scrape", "https://example.com", "--keep-alive", "30"]),
+        ("scrape --save-cookies", ["scrape", "https://example.com", "--save-cookies", str(cookies)]),
+        ("scrape --load-cookies", ["scrape", "https://example.com", "--load-cookies", str(cookies)]),
+        ("scrape --browser local", ["scrape", "https://example.com", "--browser", "local"]),
+        ("tech-detect --cdp", ["tech-detect", "https://example.com", "--cdp"]),
+        # --- direct CDPClient construction (the #3 bypasses) ---
+        ("p6", ["p6", "https://example.com", "--jar", str(jar), "--target", "https://example.com"]),
+        ("recipe", ["recipe", str(recipe)]),
+    ]
+
+
+def _has_traceback(result) -> bool:
+    """An uncaught exception that isn't the clean typer.Exit/SystemExit path
+    means the user saw a Python traceback. That's the #3 failure mode."""
+    exc = result.exception
+    return exc is not None and not isinstance(exc, SystemExit)
+
+
 class TestCdpWebsocketsGuard:
-    """Issue #3 — missing `websockets` must surface as a dependency error, early."""
+    """Issue #3 — missing `websockets` must surface as a dependency error, early,
+    for EVERY CDP-dependent command, with or without credentials."""
 
-    def test_missing_websockets_reports_dependency_not_auth(self, no_credentials):
-        # websockets absent AND no creds: the old code reported "Not authenticated"
-        # because the auth check ran first. The guard must now fire before auth.
+    @pytest.mark.parametrize("creds", [True, False], ids=["with-creds", "no-creds"])
+    def test_every_cdp_command_reports_dependency_not_auth(
+        self, creds, request, tmp_path, monkeypatch
+    ):
+        # Apply the right credential fixture: the regression is that WITHOUT
+        # creds the old code hit the auth check first ("Not authenticated"),
+        # while WITH creds it later failed deep in CDPClient. Both must now
+        # short-circuit to the dependency error.
+        request.getfixturevalue("mock_credentials" if creds else "no_credentials")
+
+        failures = []
+        for label, args in _cdp_invocations(tmp_path):
+            with patch("flarecrawl.cdp.websockets", None):
+                result = runner.invoke(app, args)
+            out = (result.output or "").lower()
+            problems = []
+            if result.exit_code != 1:
+                problems.append(f"exit={result.exit_code} (want 1)")
+            if "websockets" not in out:
+                problems.append("message does not mention 'websockets'")
+            if "not authenticated" in out or "auth login" in out:
+                problems.append("misleading auth message present")
+            if _has_traceback(result):
+                problems.append(f"raw traceback: {type(result.exception).__name__}")
+            if problems:
+                failures.append(f"  [{label}] {'; '.join(problems)}\n    output={result.output!r}")
+
+        assert not failures, "CDP dependency guard failed for:\n" + "\n".join(failures)
+
+    def test_json_mode_emits_dependency_error_envelope(self, mock_credentials):
+        """--json must yield a structured MISSING_DEPENDENCY envelope, not text
+        and not a traceback. Covers both a guarded path and a bypass path."""
+        for args in (
+            ["design", "extract", "https://example.com", "--json"],
+            ["p6", "https://example.com", "--jar", "j.json",
+             "--target", "https://example.com", "--json"],
+        ):
+            with patch("flarecrawl.cdp.websockets", None):
+                result = runner.invoke(app, args)
+            assert result.exit_code == 1, result.output
+            assert not _has_traceback(result), result.output
+            payload = json.loads(result.output)
+            assert "error" in payload, result.output
+            assert "websockets" in payload["error"]["message"].lower()
+
+    def test_install_hint_brackets_survive_rich_markup(self, mock_credentials):
+        """Regression: the actionable hint `uv pip install 'flarecrawl[cdp]'`
+        must render with the `[cdp]` extra intact in human (text) mode. Rich
+        treats `[cdp]` as a style tag and silently strips it unless the message
+        is escaped — which turned the install command into a broken one."""
         with patch("flarecrawl.cdp.websockets", None):
             result = runner.invoke(app, ["design", "extract", "https://example.com"])
+        assert "flarecrawl[cdp]" in result.output, result.output
 
-        assert result.exit_code == 1, result.output  # EXIT_ERROR, not EXIT_AUTH_REQUIRED (2)
-        assert "websockets" in result.output.lower()
-        assert "not authenticated" not in result.output.lower()
-
-    def test_missing_websockets_guarded_even_with_creds(self, mock_credentials):
+    def test_recipe_local_missing_websockets_is_clean(self, mock_credentials, tmp_path):
+        """The `recipe` bypass (direct CDPClient) used to raise an uncaught
+        FlareCrawlError → traceback. It must now exit cleanly."""
+        recipe = tmp_path / "flow.yml"
+        recipe.write_text(
+            "version: 1\ngoto: https://example.com\nbrowser: local\nsteps:\n  - wait: 100ms\n",
+            encoding="utf-8",
+        )
         with patch("flarecrawl.cdp.websockets", None):
-            result = runner.invoke(app, ["design", "extract", "https://example.com"])
-
+            result = runner.invoke(app, ["recipe", str(recipe)])
         assert result.exit_code == 1, result.output
+        assert not _has_traceback(result), result.output
         assert "websockets" in result.output.lower()
+
+    def test_recipe_dry_run_does_not_require_websockets(self, mock_credentials, tmp_path):
+        """--dry-run only validates + prints the plan; it must NOT trip the
+        dependency guard (no browser/CDP is launched)."""
+        recipe = tmp_path / "flow.yml"
+        recipe.write_text(
+            "version: 1\ngoto: https://example.com\nbrowser: local\nsteps:\n  - wait: 100ms\n",
+            encoding="utf-8",
+        )
+        with patch("flarecrawl.cdp.websockets", None):
+            result = runner.invoke(app, ["recipe", str(recipe), "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "websockets" not in result.output.lower()
+
+    def test_p6_injected_mint_fn_bypasses_websockets_guard(self, tmp_path):
+        """The early p6 guard must only fire for the default (CDP) minter, so
+        injected minters (custom flows / tests) keep working without websockets."""
+        from flarecrawl.p6 import P6Config, run_p6
+
+        cfg = P6Config(
+            mint_url="https://example.com",
+            jar_path=tmp_path / "jar.json",
+            targets=[],  # no targets → returns immediately, no replay
+        )
+        with patch("flarecrawl.cdp.websockets", None):
+            # A custom mint_fn means the CDP path is never taken; the guard
+            # must not raise. (No targets, so no network happens.)
+            result = run_p6(cfg, mint_fn=lambda *a, **k: [], replay_fn=lambda *a, **k: None)
+        assert result.targets_total == 0


### PR DESCRIPTION
Closes #3.

## Problem

`design extract` (and other CDP commands) reported a misleading "Not authenticated" — or a raw Python traceback — when the optional `websockets` package was absent, instead of naming the real cause. The earlier fix guarded the shared CDP factory (`_get_cdp_client`), but three command paths bypassed it:

- **`scrape`** with any CDP-promoting flag (`--cdp`, `--interactive`, `--live-view`, `--record`, `--keep-alive`, `--save/load-cookies`, `--browser local`, `--js-eval`, `--capture-pattern`, `--tabs > 1`) builds its REST client first, so the auth check fired **before** the dependency check → "Not authenticated" (exit 2).
- **`recipe`** (browser flows) constructs the CDP client directly → uncaught `FlareCrawlError` → raw traceback, and `--json` emitted no error envelope.
- **`p6`** had the same direct-construction bypass.

A latent rendering bug compounded it: Rich parsed the `[cdp]` in the install hint as a markup tag and silently stripped it, so the terminal printed a broken install command.

## Changes

- Extract `_require_cdp_websockets()` (single source of truth); call it from `_get_cdp_client` and early in `scrape` once a flag promotes the run to CDP, before the auth check.
- `recipe.run()` and `p6.run_p6()` guard up front, before launching a browser. p6 only guards the default (CDP) minter so injected minters still work.
- `recipe_command` catches `FlareCrawlError` → clean exit 1 + JSON envelope.
- Escape error messages in `_error` (`rich.markup.escape`) so `[cdp]` survives.
- Modernize every optional-dependency install hint from `uv pip install` → `uv tool install 'flarecrawl[extra]'` (the pip form targets the active venv, not a uv-tool-installed CLI's isolated env).

All CDP-dependent commands now fail fast before any auth/network/browser work, with exit `1` (`MISSING_DEPENDENCY`), no traceback, and a proper JSON envelope under `--json`.

## Testing

- Parametrized coverage over every CDP-dependent command (with and without credentials) asserting exit 1, a websockets message, no "not authenticated", and no traceback; plus JSON-envelope, markup-rendering, recipe-dry-run, and p6 injected-minter cases.
- Full suite green: **1609 passed, 66 skipped**.
- Verified against the real CLI in a websockets-free virtualenv (clean message, exit 1, no traceback; proceeds past the guard once websockets is installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
